### PR TITLE
Enable PyPI install with an empty Python environment.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,17 +1,31 @@
 from setuptools import find_packages, setup
+import codecs
+import os.path
 
-from msdk.lib.settings import MSDK_VERSION
+
+def read(rel_path):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), "r") as fp:
+        return fp.read()
+
+
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith("MSDK_VERSION"):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    raise RuntimeError("Unable to find version string.")
 
 
 setup(
     name="msdk",
     packages=find_packages(),
-    version=MSDK_VERSION,
+    version=get_version("msdk/lib/settings.py"),
     description="SDK for Malcore API",
     author="Thomas Perkins",
     author_email="contact@malcore.io",
     install_requires=["requests==2.31.0"],
     long_description=open("README.md").read(),
-    long_description_content_type='text/markdown',
-    url="https://github.com/Internet-2-0/Malcore-SDK"
+    long_description_content_type="text/markdown",
+    url="https://github.com/Internet-2-0/Malcore-SDK",
 )


### PR DESCRIPTION
##### A similar PR may already be submitted!
##### Please search among the [Pull request](https://github.com/Internet-2-0/Malcore-SDK/issues) before creating one.

---

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:


**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] Bug 1
* [ ] Bug 2
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes
* [ ] New language SDK

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Installation of msdk package is failing using pip due to error:
```
Processing ./Malcore-SDK/python
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [22 lines of output]
      Traceback (most recent call last):
        File "/Users/juraj/noibit/soc/malcore-test/.venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/Users/juraj/noibit/soc/malcore-test/.venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Users/juraj/noibit/soc/malcore-test/.venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/fb/9hqzvtld7cjbgz9xvv2qj2l00000gn/T/pip-build-env-60a6ho9f/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 332, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/fb/9hqzvtld7cjbgz9xvv2qj2l00000gn/T/pip-build-env-60a6ho9f/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 302, in _get_build_requires
          self.run_setup()
        File "/private/var/folders/fb/9hqzvtld7cjbgz9xvv2qj2l00000gn/T/pip-build-env-60a6ho9f/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 503, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/private/var/folders/fb/9hqzvtld7cjbgz9xvv2qj2l00000gn/T/pip-build-env-60a6ho9f/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 318, in run_setup
          exec(code, locals())
        File "<string>", line 3, in <module>
        File "/Users/juraj/noibit/soc/malcore-test/Malcore-SDK/python/msdk/lib/settings.py", line 1, in <module>
          import requests
      ModuleNotFoundError: No module named 'requests'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error
```

Proposed solution based on https://packaging.python.org/en/latest/guides/single-sourcing-package-version/

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots and/or videos if the pull request changes UI. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
